### PR TITLE
feat: Add automatic OpenAPI/Swagger UI documentation

### DIFF
--- a/recrutech-services/pom.xml
+++ b/recrutech-services/pom.xml
@@ -34,6 +34,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- SpringDoc OpenAPI for automatic API documentation -->
+            <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                <version>2.7.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/recrutech-services/recrutech-auth/pom.xml
+++ b/recrutech-services/recrutech-auth/pom.xml
@@ -207,6 +207,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+        
+        <!-- SpringDoc OpenAPI for automatic API documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/recrutech-services/recrutech-auth/src/main/java/com/recrutech/recrutechauth/config/OpenApiConfig.java
+++ b/recrutech-services/recrutech-auth/src/main/java/com/recrutech/recrutechauth/config/OpenApiConfig.java
@@ -1,0 +1,39 @@
+package com.recrutech.recrutechauth.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("RecruTech Authentication Service API")
+                        .version("0.0.1")
+                        .description("API documentation for the RecruTech Authentication Service. This service handles user authentication, registration, and JWT token management.")
+                        .contact(new Contact()
+                                .name("RecruTech Team")
+                                .email("support@recrutech.com"))
+                        .license(new License()
+                                .name("Apache 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")))
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")
+                                .description("JWT Bearer Token authentication")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"));
+    }
+}

--- a/recrutech-services/recrutech-auth/src/main/java/com/recrutech/recrutechauth/config/SecurityConfig.java
+++ b/recrutech-services/recrutech-auth/src/main/java/com/recrutech/recrutechauth/config/SecurityConfig.java
@@ -115,6 +115,8 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/reset-password", "/api/auth/reset-password-confirm").permitAll()
                 .requestMatchers("/api/gdpr/info", "/api/gdpr/health").permitAll()
                 .requestMatchers("/actuator/health").permitAll()
+                // Swagger UI and OpenAPI documentation
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                 // Static resources
                 .requestMatchers("/", "/index.html", "/favicon.ico", "/css/**", "/js/**", "/images/**", "/webjars/**").permitAll()
                 .anyRequest().authenticated())

--- a/recrutech-services/recrutech-notification/pom.xml
+++ b/recrutech-services/recrutech-notification/pom.xml
@@ -88,6 +88,12 @@
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <!-- SpringDoc OpenAPI for automatic API documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/recrutech-services/recrutech-notification/src/main/java/com/recrutech/recrutechnotification/config/OpenApiConfig.java
+++ b/recrutech-services/recrutech-notification/src/main/java/com/recrutech/recrutechnotification/config/OpenApiConfig.java
@@ -1,0 +1,27 @@
+package com.recrutech.recrutechnotification.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("RecruTech Notification Service API")
+                        .version("0.0.1")
+                        .description("API documentation for the RecruTech Notification Service. This service handles email notifications and message processing via Kafka.")
+                        .contact(new Contact()
+                                .name("RecruTech Team")
+                                .email("support@recrutech.com"))
+                        .license(new License()
+                                .name("Apache 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")));
+    }
+}

--- a/recrutech-services/recrutech-platform/pom.xml
+++ b/recrutech-services/recrutech-platform/pom.xml
@@ -107,6 +107,13 @@
             <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        
+        <!-- SpringDoc OpenAPI for automatic API documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.7.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/recrutech-services/recrutech-platform/src/main/java/com/recrutech/recrutechplatform/config/OpenApiConfig.java
+++ b/recrutech-services/recrutech-platform/src/main/java/com/recrutech/recrutechplatform/config/OpenApiConfig.java
@@ -1,0 +1,39 @@
+package com.recrutech.recrutechplatform.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("RecruTech Platform Service API")
+                        .version("0.0.1")
+                        .description("API documentation for the RecruTech Platform Service. This service handles core platform functionality including user profiles, applications, and company management.")
+                        .contact(new Contact()
+                                .name("RecruTech Team")
+                                .email("support@recrutech.com"))
+                        .license(new License()
+                                .name("Apache 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")))
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")
+                                .description("JWT Bearer Token authentication")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"));
+    }
+}


### PR DESCRIPTION
Implement SpringDoc OpenAPI for all three services (auth, platform, notification). Documentation is auto-generated from REST controllers and accessible via /swagger-ui.html